### PR TITLE
le contenu est d"sormais dans www pour ne pas exposer .git

### DIFF
--- a/roles/layers.openstreetmap.fr/files/apache
+++ b/roles/layers.openstreetmap.fr/files/apache
@@ -2,8 +2,8 @@
 <VirtualHost *:80 *:443>
         ServerName layers.openstreetmap.fr
 
-        DocumentRoot /data/project/layers.openstreetmap.fr/web
-        <Directory /data/project/layers.openstreetmap.fr/web>
+        DocumentRoot /data/project/layers.openstreetmap.fr/web/www
+        <Directory /data/project/layers.openstreetmap.fr/web/www>
                 AllowOverride all 
                 Require all granted
         </Directory>


### PR DESCRIPTION
problème (mineur) détecté lors du bug bounty du FIC2019